### PR TITLE
Created .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+.obsidian/plugins
+.obsidian/snippets
+.obsidian/themes
+.obsidian/config
+.obsidian/daily-notes
+.obsidian/starred
+.obsidian/templates
+.obsidian/workspaces


### PR DESCRIPTION
To ignore specific files and folders from `.obsidian` which are user specific and don't need to be tracked.